### PR TITLE
Fix feature leakage and metric formatting in partie4

### DIFF
--- a/partie4.py
+++ b/partie4.py
@@ -117,7 +117,8 @@ print(f"✓ Features de moyennes mobiles créées ({len(windows)} fenêtres)")
 
 # 4. Features d'interaction
 df['Hour_IsWeekend'] = df['Hour'] * df['IsWeekend']
-df['Production_Conso_Ratio'] = df['Production_totale_MW'] / (df['Consommation_MW'] + 1)
+# Utiliser la consommation de l'heure précédente pour éviter la fuite d'information
+df['Production_Conso_Ratio'] = df['Production_totale_MW'] / (df['Consommation_MW_lag_1'] + 1)
 df['Renew_Nuclear_Ratio'] = df['Production_renouvelable_MW'] / (df['Nucleaire_MW'] + 1)
 print("✓ Features d'interaction créées")
 
@@ -426,7 +427,7 @@ ax1.grid(True, alpha=0.3)
 
 # Ajouter les métriques
 textstr = f'R² = {best_model_info["test_r2"]:.3f}\n'
-textstr += f'RMSE = {best_model_info["test_rmse"]}:.1f MWh\n'
+textstr += f'RMSE = {best_model_info["test_rmse"]:.1f} MWh\n'
 textstr += f'MAPE = {best_model_info["test_mape"]:.2f}%'
 props = dict(boxstyle='round', facecolor='wheat', alpha=0.5)
 ax1.text(0.05, 0.95, textstr, transform=ax1.transAxes, fontsize=10,


### PR DESCRIPTION
## Summary
- avoid target leakage in `Production_Conso_Ratio` by using the previous hour's consumption
- correct RMSE formatting in prediction plot
- add missing newline at EOF

## Testing
- `python -m py_compile partie4.py`

------
https://chatgpt.com/codex/tasks/task_e_684ccb607fb08329b16ad85e39f0e9fe